### PR TITLE
Fix trade evolutions

### DIFF
--- a/data/pokemon/evos_moves.asm
+++ b/data/pokemon/evos_moves.asm
@@ -772,8 +772,8 @@ SlowpokeEvosMoves:
 
 KadabraEvosMoves:
 ; Evolutions
-	db EVOLVE_LEVEL, 37, ALAKAZAM
 	db EVOLVE_TRADE, 1, ALAKAZAM
+	db EVOLVE_LEVEL, 37, ALAKAZAM
 	db 0
 ; Learnset
 	db 16, CONFUSION
@@ -787,8 +787,8 @@ KadabraEvosMoves:
 
 GravelerEvosMoves:
 ; Evolutions
-	db EVOLVE_LEVEL, 37, GOLEM
 	db EVOLVE_TRADE, 1, GOLEM
+	db EVOLVE_LEVEL, 37, GOLEM
 	db 0
 ; Learnset
 	db 11, HARDEN
@@ -821,8 +821,8 @@ ChanseyEvosMoves:
 
 MachokeEvosMoves:
 ; Evolutions
-	db EVOLVE_LEVEL, 37, MACHAMP
 	db EVOLVE_TRADE, 1, MACHAMP
+	db EVOLVE_LEVEL, 37, MACHAMP
 	db 0
 ; Learnset
 	db 15, LOW_KICK
@@ -2091,8 +2091,8 @@ MarowakEvosMoves:
 
 HaunterEvosMoves:
 ; Evolutions
-	db EVOLVE_LEVEL, 37, GENGAR
 	db EVOLVE_TRADE, 1, GENGAR
+	db EVOLVE_LEVEL, 37, GENGAR
 	db 0
 ; Learnset
 	db 21, HYPNOSIS


### PR DESCRIPTION
Before this commit, none of the pokémon normally capable of trade evolutions would evolve when they were traded. The reason is found in the lines 79 to 98 of engine/pokemon/evos_moves.asm, which loops through the list of evolution methods provided for the pokémon that the function is currently handling.
That part of the function Evolution_PartyMonLoop first tests whether the currently inspected evolution method is EVOLVE_TRADE. Then, if the evolution method is not EVOLVE_TRADE, it checks whether a trade is going on by comparing to the LINK_STATE_TRADING constant. If a trade is indeed going on, the currently handled pokémon is entirely skipped without looking at its other evolution methods.

In other words, the EVOLVE_TRADE entry in a pokémon's evolution methods needs to come first in data/pokemon/evos_moves.asm, or the mentioned part of Evolution_PartyMonLoop needs to be changed. With this commit, I opted to do the former and swapped the order of the EVOLVE_TRADE and EVOLVE_LEVEL entries for Haunter, Graveler, Kadabra and Machoke. This also retains their ability to evolve at level 37 since the function doesn't skip the pokémon under circumstances that allow it to level up, and properly loops through all of the pokémon's evolution methods.