### PR TITLE
fix: Count Volcanic Magmar as Magmar during signature move check

### DIFF
--- a/engine/battle/remap_move_data.asm
+++ b/engine/battle/remap_move_data.asm
@@ -13,6 +13,10 @@ CheckRemapMoveData::
 	cp -1
 	jr z, .donePokemonCheck
 	ld a, d
+	cp VOLCANIC_MAGMAR
+	jr nz, .notVolcanicMagmar
+	ld a, MAGMAR ; treat VOLCANIC_MAGMAR as MAGMAR when checking for signature moves
+.notVolcanicMagmar
 	cp [hl]
 	ret nz
 .donePokemonCheck
@@ -66,8 +70,8 @@ GetMoveRemapData2:
 
 ; byte 1 = move
 ; byte 2 = required pokemon for modifier or -1 for any pokemon
-; byte 4 = modified power or -1 if no change or -2 if the move uses a modifier function
-; byte 3 = modified accuracy or 0 if no accuracy change, or which modifier function to use if previous byte was -2
+; byte 3 = modified power or -1 if no change or -2 if the move uses a modifier function
+; byte 4 = modified accuracy or 0 if no accuracy change, or which modifier function to use if previous byte was -2
 RemappableMoves::
 	db SING, -1, -2, 1
 	db DOUBLESLAP, -1, -2, 0


### PR DESCRIPTION
Without this change, upgrading Magmar to Volcanic Magmar makes it lose access to the signature move benefits of Fire Punch. I assumed that wasn't intentional, so I added a couple of lines to treat Volcanic Magmar as Magmar when checking for a signature move in RemappableMoves.

Also, this corrects what I reckon is a typo in the comments that explain the RemappableMoves list.