### PR TITLE
Treat .ips release patches as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 *.wav binary
 *.blk binary
 *.pic binary
+*.ips binary
 
 # Declare files that will always have CRLF line endings on checkout.
 *.patch.template text eol=crlf linguist-language=INI

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 *.blk binary
 *.pic binary
 *.ips binary
+*.bps binary
 
 # Declare files that will always have CRLF line endings on checkout.
 *.patch.template text eol=crlf linguist-language=INI


### PR DESCRIPTION
One-line fix for gitattributes. 

.gitattributes doesn't list `*.ips` as a binary type, and therefore Git is stripping CR from CRLF pairs on commit. All of the in-repo `releases/*.ips` files are being corrupted as a result (the published releases are fine).